### PR TITLE
fix(): fix issue entity name typo in repository attr

### DIFF
--- a/src/LIB/Generation/SchematicBuilder.php
+++ b/src/LIB/Generation/SchematicBuilder.php
@@ -183,7 +183,7 @@ final class SchematicBuilder
 
         $fileContent = file_get_contents($repositoryPath);
         $entityName = basename($path, '.php');
-        $fileContent = str_replace("entity: ''", sprintf("entity: %s::class", $entityName), $fileContent);
+        $fileContent = str_replace("entity: ''", sprintf("entity: %sEntity::class", $entityName), $fileContent);
 
         $filesize = file_put_contents($repositoryPath, $fileContent);
 


### PR DESCRIPTION
- fixes issue where the Entity class suffix is missing from entity reference in the repository attribute declaration.